### PR TITLE
Common - Improve automatic detection of passengers

### DIFF
--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -6,13 +6,11 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class Heli_Transport_03_base_F: Helicopter_Base_H {
-        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
         GVARMAIN(rampAnims)[] = {{"Door_rear_source", 0, 1}}; // animationSource, closedState, openState
     };
 
     class VTOL_01_unarmed_base_F;
     class VTOL_01_infantry_base_F: VTOL_01_unarmed_base_F {
-        GVARMAIN(passengerTurrets)[] = {{3}, {4}}; // Left and right ramp seats
         GVARMAIN(rampAnims)[] = {{"Door_1_source", 0, 1}};
     };
 };

--- a/addons/common/functions/fnc_getPassengers.sqf
+++ b/addons/common/functions/fnc_getPassengers.sqf
@@ -10,7 +10,7 @@
  * Array of passenger units <ARRAY>
  *
  * Example:
- * [_vehicle] call aftb_common_fnc_getPassengers
+ * _vehicle call aftb_common_fnc_getPassengers
  *
  * Public: Yes
  */
@@ -23,6 +23,9 @@ TRACE_1("fnc_getPassengers",_vehicle);
 private _passengerTurrets = getArray (configOf _vehicle >> QGVARMAIN(passengerTurrets));
 private _passengers = fullCrew _vehicle select {
     _x params ["", "_role", "", "_turretPath"];
-    _role == "cargo" or {_turretPath in _passengerTurrets};
+    _role == "cargo" or {_turretPath in _passengerTurrets} or {
+        private _turretConfig = [_vehicle, _turretPath] call CBA_fnc_getTurret;
+        getNumber (_turretConfig >> "showAsCargo") == 1 and {getNumber (_turretConfig >> "isPersonTurret") == 1};
+    };
 } apply { _x#0 };
 _passengers;

--- a/addons/compat_csla/CfgVehicles.hpp
+++ b/addons/compat_csla/CfgVehicles.hpp
@@ -2,18 +2,9 @@ class CfgVehicles {
     class Helicopter_Base_H;
     class US85_Helicopter_Base_H: Helicopter_Base_H {
         GVARMAIN(rampAnims)[] = {{"", 0, 0}};
-        EGVAR(helocast,boatPositions)[] = {
-            {0, 1.8, 1}
-        };
+
+        EGVAR(helocast,boatPositions)[] = {{0, 1.8, 1}};
         EGVAR(helocast,marker) = "Chemlight_green";
         EGVAR(helocast,drop) = 1;
-    };
-
-    class US85_H60;
-    class US85_MH60M134: US85_H60 {
-        GVARMAIN(passengerTurrets)[] = {
-            {3}, {4},
-            {5}, {6}
-        };
     };
 };

--- a/addons/compat_cup_vehicles/CfgVehicles.hpp
+++ b/addons/compat_cup_vehicles/CfgVehicles.hpp
@@ -1,6 +1,6 @@
 class CfgVehicles {
     class Helicopter_Base_H;
-    class CUP_Uh60_Base: Helicopter_Base_H {
+    class CUP_UH60_Base: Helicopter_Base_H {
         GVARMAIN(rampAnims)[] = {{"", 0, 0}};
 
         EGVAR(helocast,boatPositions)[] = {
@@ -8,13 +8,6 @@ class CfgVehicles {
         };
         EGVAR(helocast,marker) = "Chemlight_green";
         EGVAR(helocast,drop) = 1;
-    };
-
-    class CUP_Uh60_FFV_Base: CUP_Uh60_Base {
-        GVARMAIN(passengerTurrets)[] = {
-            {3}, {4},
-            {5}, {6}
-        };
     };
 
     class CUP_MH60S_Base: Helicopter_Base_H {

--- a/addons/compat_ls/CfgVehicles.hpp
+++ b/addons/compat_ls/CfgVehicles.hpp
@@ -1,24 +1,9 @@
 class CfgVehicles {
     class Helicopter_Base_H;
     class lsd_laat_base: Helicopter_Base_H {
-        GVARMAIN(passengerTurrets)[] = {
-            // Left and right ramp seats, side seats, inside standing seats
-            {1}, {2},
-            {3}, {4},
-            {5}, {6},
-            {7}, {8},
-            {9}, {10},
-            {11}, {12},
-            {13}, {15},
-            {16}, {17},
-            {18}, {19},
-            {20}
-        };
         GVARMAIN(rampAnims)[] = {{"laat_ramp_open", 0, 1}};
 
-        EGVAR(helocast,boatPositions)[] = {
-            {0, -3, 0.2}
-        };
+        EGVAR(helocast,boatPositions)[] = {{0, -3, 0.2}};
         EGVAR(helocast,marker) = "Chemlight_green";
     };
     class lsd_heli_laati_ab: lsd_laat_base {

--- a/addons/compat_optre/CfgVehicles.hpp
+++ b/addons/compat_optre/CfgVehicles.hpp
@@ -11,10 +11,7 @@ class CfgVehicles {
 
     class Helicopter_Base_H;
     class OPTRE_Pelican_F: Helicopter_Base_H {
-        GVARMAIN(passengerTurrets)[] = {{1}, {2}};
-        GVARMAIN(rampAnims)[] = {
-            {"cargoDoors", 0, 1}
-        };
+        GVARMAIN(rampAnims)[] = {{"cargoDoors", 0, 1}};
 
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);

--- a/addons/compat_optre_fc/CfgVehicles.hpp
+++ b/addons/compat_optre_fc/CfgVehicles.hpp
@@ -1,15 +1,7 @@
 class CfgVehicles {
     class Helicopter_Base_F;
     class OPTRE_FC_Spirit_F: Helicopter_Base_F {
-        GVARMAIN(passengerTurrets)[] = {
-            {1},  {2},  {3},  {4},
-            {5},  {6},  {7},  {8},
-            {9},  {10}, {11}, {12},
-            {13}, {14}, {15}, {16}
-        };
-        GVARMAIN(rampAnims)[] = {
-            {"cargoDoors", 0, 1}
-        };
+        GVARMAIN(rampAnims)[] = {{"cargoDoors", 0, 1}};
 
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);

--- a/addons/compat_rhs_usaf/CfgVehicles.hpp
+++ b/addons/compat_rhs_usaf/CfgVehicles.hpp
@@ -12,10 +12,6 @@ class CfgVehicles {
     class RHS_UH60_Base;
     class RHS_UH60M_base: RHS_UH60_Base {
         GVARMAIN(rampAnims)[] = {{"", 0, 0}};
-        GVARMAIN(passengerTurrets)[] = {
-            {3}, {4},
-            {5}, {6}
-        };
 
         EGVAR(helocast,boatPositions)[] = {
             {0, 1.8, -1.45}
@@ -27,9 +23,6 @@ class CfgVehicles {
     class Heli_Transport_02_base_F;
     class RHS_CH_47F_base: Heli_Transport_02_base_F {
         GVARMAIN(rampAnims)[] = {{"ramp_anim", 0, 1}};
-        GVARMAIN(passengerTurrets)[] = {
-            {3}, {4}
-        };
 
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);

--- a/addons/compat_sog/cfg/helicopters.hpp
+++ b/addons/compat_sog/cfg/helicopters.hpp
@@ -1,6 +1,5 @@
 class vn_air_ch47_04_base;
 class vn_b_air_ch47_04_01: vn_air_ch47_04_base {
-    GVARMAIN(passengerTurrets)[] = {{1}, {2}};
     GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
 
     EGVAR(staticLine,enabled) = 1;
@@ -10,7 +9,6 @@ class vn_b_air_ch47_04_01: vn_air_ch47_04_base {
     EGVAR(helocast,marker) = "Chemlight_green";
 };
 class vn_b_air_ch47_04_02: vn_air_ch47_04_base {
-    GVARMAIN(passengerTurrets)[] = {{1}, {2}};
     GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
 
     EGVAR(staticLine,enabled) = 1;
@@ -22,7 +20,6 @@ class vn_b_air_ch47_04_02: vn_air_ch47_04_base {
 
 class vn_air_ch47_01_base;
 class vn_b_air_ch47_01_01: vn_air_ch47_01_base {
-    GVARMAIN(passengerTurrets)[] = {{1}, {2}};
     GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
 
     EGVAR(staticLine,enabled) = 1;
@@ -33,7 +30,6 @@ class vn_b_air_ch47_01_01: vn_air_ch47_01_base {
 };
 
 class vn_b_air_ch47_01_02: vn_air_ch47_01_base {
-    GVARMAIN(passengerTurrets)[] = {{1}, {2}};
     GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
 
     EGVAR(staticLine,enabled) = 1;

--- a/addons/compat_tf373/CfgVehicles.hpp
+++ b/addons/compat_tf373/CfgVehicles.hpp
@@ -2,9 +2,6 @@ class CfgVehicles {
     class Helicopter_Base_H;
     class TF373_SOAR_MH47G_Base: Helicopter_Base_H {
         GVARMAIN(rampAnims)[] = {{"ramp", 1, 0}};
-        GVARMAIN(passengerTurrets)[] = {
-            {3}, {4}
-        };
 
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);

--- a/addons/compat_uk3cb/CfgVehicles.hpp
+++ b/addons/compat_uk3cb/CfgVehicles.hpp
@@ -2,9 +2,6 @@ class CfgVehicles {
     class Heli_Transport_02_base_F;
     class UK3CB_BAF_Merlin_Base: Heli_Transport_02_base_F {
         GVARMAIN(rampAnims)[] = {{"CargoRamp_Open", 0, 1}};
-        GVARMAIN(passengerTurrets)[] = {
-            {1}, {2}
-        };
 
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -1,7 +1,6 @@
 // Global toggles for caching/logging
 // #define DISABLE_COMPILE_CACHE
 // #define DEBUG_MODE_FULL
-#define DEBUG_SYNCHRONOUS
 
 #include "\z\ace\addons\main\script_macros.hpp"
 

--- a/docs/frameworks/common-functionality.md
+++ b/docs/frameworks/common-functionality.md
@@ -17,13 +17,13 @@ class CfgVehicles {
 };
 ```
 
-| Config Name                | Type             | Description                                                       |
-| -------------------------- | ---------------- | ----------------------------------------------------------------- |
-| `aftb_passengerTurrets`     | Array            | Turret paths for seats that can also static line jump (OPTIONAL)  |
-| `aftb_rampAnim`             | Array            | Door animations, (at least one) must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
+| Config Name                | Type             | Description                                                |
+| -------------------------- | ---------------- | ---------------------------------------------------------- |
+| `aftb_passengerTurrets`    | Array            | Extra turret paths to also consider passengers. (OPTIONAL) |
+| `aftb_rampAnim`            | Array            | Door animation(s) that one of must be open for players to jump. ["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
 
 > [!NOTE]
-> If a vehicle does not have a ramp, you can use `["", 0, 0]` to have "is ramp open" checks always be true.
+> If a vehicle does not have a ramp, you can use `["", 0, 0]` have a vehicle's ramp always be considered open.
 
 ### 1.2 Parachutes
 Some parachutes classes may not inherit from `B_Parachute`, the vanilla parachute class. To remedy this, AFTB will consider any backpack to be a parachute if it has the `aftb_isParachute` config property set to 1 (or greater). What each component does with a parachute will vary.


### PR DESCRIPTION
**When merged this pull request will:**
- Check `showAsCargo` and `isPersonTurret` in the turret config to determine if a given unit is a passenger.
  - This means that `passengerTurrets` could be used exclusively for extra seats to consider passengers.

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartRuffian/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartRuffian/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None