### PR TITLE
Compabitility - Add Global Mobilization plane support for Static Line

### DIFF
--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -5,7 +5,7 @@ class CfgVehicles {
         aftb_staticLine_condition = "true";
     };
     class gm_do28d2_medevac_base : gm_do28d2_base {
-    aftb_staticLine_enabled = 0;
+        aftb_staticLine_enabled = 0;
         aftb_staticLine_condition = "true";
     };
     class gm_l410_base;

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -4,7 +4,7 @@ class CfgVehicles {
         aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
     };
-    class gm_do28d2_medevac_base : gm_do28d2_base {
+    class gm_do28d2_medevac_base: gm_do28d2_base {
         aftb_staticLine_enabled = 0;
         aftb_staticLine_condition = "true";
     };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -5,18 +5,18 @@ class CfgVehicles {
             {"", 0, 0}
         };
         EGVAR(staticLine,enabled) = 1;
-        aftb_staticLine_condition = "true";
+        EGVAR(staticLine,condition) = "true";
     };
     class gm_do28d2_medevac_base: gm_do28d2_base {
-        aftb_staticLine_enabled = 0;
-        aftb_staticLine_condition = "true";
+        EGVAR(staticLine,enabled) = 0;
+        EGVAR(staticLine,condition) = "true";
     };
     class gm_l410_base;
     class gm_l410t_base: gm_l410_base {
-        aftb_rampAnims[] = {
+        GVARMAIN(rampAnims)[] = {
             {"", 0, 0}
         };
-        aftb_staticLine_enabled = 1;
-        aftb_staticLine_condition = "true";
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = "true";
     };
 };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -4,7 +4,7 @@ class CfgVehicles {
         GVARMAIN(rampAnims)[] = {
             {"", 0, 0}
         };
-        aftb_staticLine_enabled = 1;
+        EGVAR(staticLine,enabled) = 1;
         aftb_staticLine_condition = "true";
     };
     class gm_do28d2_medevac_base: gm_do28d2_base {

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -9,7 +9,7 @@ class CfgVehicles {
     };
     class gm_do28d2_medevac_base: gm_do28d2_base {
         EGVAR(staticLine,enabled) = 0;
-        EGVAR(staticLine,condition) = "true";
+        EGVAR(staticLine,condition) = "false";
     };
     class gm_l410_base;
     class gm_l410t_base: gm_l410_base {

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -9,7 +9,7 @@ class CfgVehicles {
         aftb_staticLine_condition = "true";
     };
     class gm_l410_base;
-    class gm_l410t_base : gm_l410_base {
+    class gm_l410t_base: gm_l410_base {
         aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
     };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -1,6 +1,9 @@
 class CfgVehicles {
     class gm_plane_base;
     class gm_do28d2_base: gm_plane_base {
+        aftb_rampAnims[] = {
+            {["", 0, 0]}
+        };
         aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
     };
@@ -10,6 +13,9 @@ class CfgVehicles {
     };
     class gm_l410_base;
     class gm_l410t_base: gm_l410_base {
+        aftb_rampAnims[] = {
+            {["", 0, 0]}
+        };
         aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
     };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -1,2 +1,16 @@
 class CfgVehicles {
+	class gm_plane_base;
+	class gm_do28d2_base : gm_plane_base {
+		aftb_staticLine_enabled = 1;
+        aftb_staticLine_condition = "true";
+	};
+	class gm_do28d2_medevac_base : gm_do28d2_base {
+		aftb_staticLine_enabled = 0;
+        aftb_staticLine_condition = "true";
+	};
+	class gm_l410_base;
+	class gm_l410t_base : gm_l410_base {
+		aftb_staticLine_enabled = 1;
+        aftb_staticLine_condition = "true";
+	};
 };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -1,6 +1,6 @@
 class CfgVehicles {
     class gm_plane_base;
-    class gm_do28d2_base : gm_plane_base {
+    class gm_do28d2_base: gm_plane_base {
         aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
     };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -1,16 +1,16 @@
 class CfgVehicles {
-	class gm_plane_base;
-	class gm_do28d2_base : gm_plane_base {
-		aftb_staticLine_enabled = 1;
+    class gm_plane_base;
+    class gm_do28d2_base : gm_plane_base {
+        aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
-	};
-	class gm_do28d2_medevac_base : gm_do28d2_base {
-		aftb_staticLine_enabled = 0;
+    };
+    class gm_do28d2_medevac_base : gm_do28d2_base {
+    aftb_staticLine_enabled = 0;
         aftb_staticLine_condition = "true";
-	};
-	class gm_l410_base;
-	class gm_l410t_base : gm_l410_base {
-		aftb_staticLine_enabled = 1;
+    };
+    class gm_l410_base;
+    class gm_l410t_base : gm_l410_base {
+        aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
-	};
+    };
 };

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -1,7 +1,7 @@
 class CfgVehicles {
     class gm_plane_base;
     class gm_do28d2_base: gm_plane_base {
-        aftb_rampAnims[] = {
+        GVARMAIN(rampAnims)[] = {
             {"", 0, 0}
         };
         aftb_staticLine_enabled = 1;

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class CfgVehicles {
     class gm_plane_base;
     class gm_do28d2_base: gm_plane_base {
         aftb_rampAnims[] = {
-            {["", 0, 0]}
+            {"", 0, 0}
         };
         aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";
@@ -14,7 +14,7 @@ class CfgVehicles {
     class gm_l410_base;
     class gm_l410t_base: gm_l410_base {
         aftb_rampAnims[] = {
-            {["", 0, 0]}
+            {"", 0, 0}
         };
         aftb_staticLine_enabled = 1;
         aftb_staticLine_condition = "true";


### PR DESCRIPTION
Add static line compatibility for GM west and east planes

**When merged this pull request will:**
- Adds static line ability to Do 28 D2 and L410T planes for GM


### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- [ ] None