### PR TITLE
General - Use ACE Common's `Enabled` key

### DIFF
--- a/addons/helocast/initSettings.inc.sqf
+++ b/addons/helocast/initSettings.inc.sqf
@@ -1,6 +1,6 @@
 [
     QGVAR(enabled), "CHECKBOX",
-    [LSTRING(enabled_name), LSTRING(enabled_tooltip)],
+    [localize "STR_ACE_Common_Enabled", LSTRING(enabled_tooltip)],
     _category, true, true
 ] call CBA_fnc_addSetting;
 

--- a/addons/helocast/stringtable.xml
+++ b/addons/helocast/stringtable.xml
@@ -19,9 +19,6 @@
         <Key ID="STR_AFTB_helocast_displayName">
             <English>Helocast</English>
         </Key>
-        <Key ID="STR_AFTB_helocast_enabled_name">
-            <English>Enabled</English>
-        </Key>
         <Key ID="STR_AFTB_helocast_enabled_tooltip">
             <English>Enables / disables helocasting.</English>
         </Key>

--- a/addons/staticline/initSettings.inc.sqf
+++ b/addons/staticline/initSettings.inc.sqf
@@ -1,6 +1,6 @@
 [
     QGVAR(enabled), "CHECKBOX",
-    [LSTRING(enabled_name), LSTRING(enabled_tooltip)],
+    [localize "STR_ACE_Common_Enabled", LSTRING(enabled_tooltip)],
     _category, true, true
 ] call CBA_fnc_addSetting;
 

--- a/addons/staticline/stringtable.xml
+++ b/addons/staticline/stringtable.xml
@@ -40,9 +40,6 @@
         <Key ID="STR_AFTB_staticLine_displayName">
             <English>Static Line Jump</English>
         </Key>
-        <Key ID="STR_AFTB_staticLine_enabled_name">
-            <English>Enabled</English>
-        </Key>
         <Key ID="STR_AFTB_staticLine_enabled_tooltip">
             <English>Enables / disables static line jumping from vehicles.</English>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**
- Use `STR_ACE_Common_Enabled` instead of making a unique `enabled_name` key in each component

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None