### PR TITLE
Common - Make level ramps count as open

### DIFF
--- a/addons/compat_cup_vehicles/CfgVehicles.hpp
+++ b/addons/compat_cup_vehicles/CfgVehicles.hpp
@@ -31,7 +31,7 @@ class CfgVehicles {
     };
 
     class CUP_CH53E_Base: Helicopter_Base_H {
-        GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+        GVARMAIN(rampAnims)[] = {{"ramp", 0, 0.56}};
 
         EGVAR(helocast,boatPositions)[] = {
             {0, 1.6, -2.7},
@@ -43,7 +43,7 @@ class CfgVehicles {
     class Plane_Base_F;
     class CUP_B_MV22_USMC: Plane_Base_F {
         GVARMAIN(rampAnims)[] = {
-            {"ramp_bottom", 0, 1},
+            {"ramp_bottom", 0, 0.56},
             {"ramp_top", 0, 1}
         };
 
@@ -55,7 +55,7 @@ class CfgVehicles {
 
     class CUP_C130J_Base: Plane_Base_F {
         GVARMAIN(rampAnims)[] = {
-            {"ramp_bottom", 0, 1},
+            {"ramp_bottom", 0, 0.7},
             {"ramp_top", 0, 1}
         };
 

--- a/addons/compat_gm/CfgVehicles.hpp
+++ b/addons/compat_gm/CfgVehicles.hpp
@@ -1,21 +1,19 @@
 class CfgVehicles {
     class gm_plane_base;
     class gm_do28d2_base: gm_plane_base {
-        GVARMAIN(rampAnims)[] = {
-            {"", 0, 0}
-        };
+        GVARMAIN(rampAnims)[] = {{"", 0, 0}};
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);
     };
+
     class gm_do28d2_medevac_base: gm_do28d2_base {
         EGVAR(staticLine,enabled) = 0;
         EGVAR(staticLine,condition) = QUOTE(false);
     };
+
     class gm_l410_base;
     class gm_l410t_base: gm_l410_base {
-        GVARMAIN(rampAnims)[] = {
-            {"", 0, 0}
-        };
+        GVARMAIN(rampAnims)[] = {{"", 0, 0}};
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);
     };

--- a/addons/compat_rhs_usaf/CfgVehicles.hpp
+++ b/addons/compat_rhs_usaf/CfgVehicles.hpp
@@ -1,7 +1,7 @@
 class CfgVehicles {
     class Helicopter_Base_H;
     class rhsusf_CH53E_USMC: Helicopter_Base_H {
-        GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+        GVARMAIN(rampAnims)[] = {{"ramp", 0, 0.56}};
 
         EGVAR(helocast,boatPositions)[] = {
             {0, 5.75, -2.59},
@@ -22,7 +22,7 @@ class CfgVehicles {
 
     class Heli_Transport_02_base_F;
     class RHS_CH_47F_base: Heli_Transport_02_base_F {
-        GVARMAIN(rampAnims)[] = {{"ramp_anim", 0, 1}};
+        GVARMAIN(rampAnims)[] = {{"ramp_anim", 0, 0.6}};
 
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);
@@ -41,7 +41,7 @@ class CfgVehicles {
 
     class Plane_Base_F;
     class RHS_C130J_Base: Plane_Base_F {
-        GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+        GVARMAIN(rampAnims)[] = {{"ramp", 0, 0.65}};
 
         EGVAR(staticLine,enabled) = 1;
         EGVAR(staticLine,condition) = QUOTE(true);

--- a/addons/compat_sog/cfg/helicopters.hpp
+++ b/addons/compat_sog/cfg/helicopters.hpp
@@ -1,6 +1,6 @@
 class vn_air_ch47_04_base;
 class vn_b_air_ch47_04_01: vn_air_ch47_04_base {
-    GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+    GVARMAIN(rampAnims)[] = {CH47_HELOCAST_RAMPANIMS};
 
     EGVAR(staticLine,enabled) = 1;
     EGVAR(staticLine,condition) = QUOTE(true);
@@ -9,7 +9,7 @@ class vn_b_air_ch47_04_01: vn_air_ch47_04_base {
     EGVAR(helocast,marker) = "Chemlight_green";
 };
 class vn_b_air_ch47_04_02: vn_air_ch47_04_base {
-    GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+    GVARMAIN(rampAnims)[] = {CH47_HELOCAST_RAMPANIMS};
 
     EGVAR(staticLine,enabled) = 1;
     EGVAR(staticLine,condition) = QUOTE(true);
@@ -20,7 +20,7 @@ class vn_b_air_ch47_04_02: vn_air_ch47_04_base {
 
 class vn_air_ch47_01_base;
 class vn_b_air_ch47_01_01: vn_air_ch47_01_base {
-    GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+    GVARMAIN(rampAnims)[] = {CH47_HELOCAST_RAMPANIMS};
 
     EGVAR(staticLine,enabled) = 1;
     EGVAR(staticLine,condition) = QUOTE(true);
@@ -30,7 +30,7 @@ class vn_b_air_ch47_01_01: vn_air_ch47_01_base {
 };
 
 class vn_b_air_ch47_01_02: vn_air_ch47_01_base {
-    GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+    GVARMAIN(rampAnims)[] = {CH47_HELOCAST_RAMPANIMS};
 
     EGVAR(staticLine,enabled) = 1;
     EGVAR(staticLine,condition) = QUOTE(true);

--- a/addons/compat_sog/script_macros.hpp
+++ b/addons/compat_sog/script_macros.hpp
@@ -1,1 +1,2 @@
 #define CH47_HELOCAST_BOATPOS {0, 0, -1.5}
+#define CH47_HELOCAST_RAMPANIMS {"ramp", 0, 0.606}

--- a/addons/compat_usaf_utility/CfgVehicles.hpp
+++ b/addons/compat_usaf_utility/CfgVehicles.hpp
@@ -3,7 +3,7 @@ class CfgVehicles {
     class USAF_C130J_Base: Plane_Base_F {
         GVARMAIN(rampAnims)[] = {
             {"ramp_top", 0, 1},
-            {"ramp_bottom", 0, 1}
+            {"ramp_bottom", 0, 0.5}
         };
 
         EGVAR(staticLine,enabled) = 1;

--- a/docs/wiki/frameworks/common.md
+++ b/docs/wiki/frameworks/common.md
@@ -24,10 +24,12 @@ class CfgVehicles {
 | Config Name             | Type  | Description                                                                                                                                                   |
 | ----------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `aftb_passengerTurrets` | Array | Extra turret paths to also consider passengers. (OPTIONAL)                                                                                                    |
-| `aftb_rampAnim`         | Array | Door animation(s) that one of must be open for players to jump. \["animationSource", closedState, openState]. Closed/open states default to 0/1 respectively. |
+| `aftb_rampAnim`         | Array | Door animation(s) that one of must be open for players to jump. \["animationSource", closedState, minimumOpenState]. Closed/open states default to 0/1 respectively. |
 
 {% hint style="info" %}
 If a vehicle does not have a ramp, you can use `{"", 0, 0}` have a vehicle's ramp always be considered open.
+
+"minimumOpenState" is the minimum amount that the ramp needs to be opened to count as "open". For vehicles that can level their ramps, this value will be around ~0.5. Meaning that any amount higher than 0.5 will count as open.
 {% endhint %}
 
 ### 1.2 Parachutes


### PR DESCRIPTION
**When merged this pull request will:**
- Change the open levels of vehicles with "level ramp" actions.
  - This will make level (or fully open) ramps count as "open"

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None