### PR TITLE
Common - Improve caching

### DIFF
--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -1,7 +1,5 @@
 #include "script_component.hpp"
 
-GVAR(parachuteCache) = createHashMapFromArray [["", false]];
-
 [QGVAR(disableCollision), {
     params ["_object"];
     _object setVariable [QGVAR(originalMass), getMass _object];

--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -3,3 +3,6 @@
 PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
+
+GVAR(rampAnimationsCache) = createHashMap;
+GVAR(parachuteCache) = createHashMapFromArray [["", false]];

--- a/addons/common/functions/fnc_getRampAnimations.sqf
+++ b/addons/common/functions/fnc_getRampAnimations.sqf
@@ -23,14 +23,11 @@ params [
 ];
 TRACE_1("fnc_getRampAnimations",_vehicle);
 
-private _rampAnims = _vehicle getVariable [QGVARMAIN(rampAnims), []];
-if (_rampAnims isNotEqualTo []) exitWith { _rampAnims; };
-
-_rampAnims = getArray (configOf _vehicle >> QGVARMAIN(rampAnims));
-_rampAnims = _rampAnims apply {
-    _x params ["_anim", ["_closed", 0], ["_opened", 1]];
-    [_anim, _closed, _opened];
-};
-
-_vehicle setVariable [QGVARMAIN(rampAnims), _rampAnims];
-_rampAnims;
+GVAR(rampAnimationsCache) getOrDefaultCall [typeOf _vehicle, {
+    private _rampAnims = getArray (configOf _vehicle >> QGVARMAIN(rampAnims));
+    _rampAnims = _rampAnims apply {
+        _x params ["_anim", ["_closed", 0], ["_opened", 1]];
+        [_anim, _closed, _opened];
+    };
+    _rampAnims;
+}, true];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `parachuteCache` only being defined in postInit, not preInit
- Use a hashmap to cache ramp animations, rather than saving it to the vehicle

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None