### PR TITLE
Compatibility - Add JLTS and 3AS Compats

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -22,6 +22,13 @@ workshop = [
     "2162749089", # Legion Studios: Core
 ]
 
+[tas]
+extends = "default"
+workshop = [
+    "1940589429", # Just Like The Simulations - The Great War
+    "2058554822", # 3AS (Beta Test)
+]
+
 [optre]
 extends = "default"
 workshop = [

--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -22,11 +22,17 @@ workshop = [
     "2162749089", # Legion Studios: Core
 ]
 
-[tas]
+[jlts]
 extends = "default"
 workshop = [
     "1940589429", # Just Like The Simulations - The Great War
+]
+
+[tas]
+extends = "jlts"
+workshop = [
     "2058554822", # 3AS (Beta Test)
+    "2215872933", # 3AS Terrains (Beta)
 ]
 
 [optre]

--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -1,7 +1,7 @@
 class CfgVehicles {
     class Bag_Base;
     class B_Parachute: Bag_Base {
-        GVARMAIN(isParachute) = 1; // Not required, since condition also checks `isKindOf B_Parachute`, but here for demonstration
+        GVARMAIN(isParachute) = 1;
     };
 
     class Helicopter_Base_H;

--- a/addons/compat_jlts/$PBOPREFIX$
+++ b/addons/compat_jlts/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\aftb\addons\compat_jlts

--- a/addons/compat_jlts/CfgVehicles.hpp
+++ b/addons/compat_jlts/CfgVehicles.hpp
@@ -1,0 +1,26 @@
+class CfgVehicles {
+    class B_Kitbag_rgr;
+    class JLTS_Clone_jumppack_Chicken: B_Kitbag_rgr {
+        GVARMAIN(isParachute) = 1;
+    };
+
+    class JLTS_Clone_jumppack_JT12: B_Kitbag_rgr {
+        GVARMAIN(isParachute) = 1;
+    };
+
+    class JLTS_Clone_jumppack_mc: B_Kitbag_rgr {
+        GVARMAIN(isParachute) = 1;
+    };
+
+    class JLTS_Clone_jumppack: B_Kitbag_rgr {
+        GVARMAIN(isParachute) = 1;
+    };
+
+    class JLTS_Clone_jumppack_mc: B_Kitbag_rgr {
+        GVARMAIN(isParachute) = 1;
+    };
+
+    class JLTS_B1_jetpack: B_Kitbag_rgr {
+        GVARMAIN(isParachute) = 1;
+    };
+};

--- a/addons/compat_jlts/CfgVehicles.hpp
+++ b/addons/compat_jlts/CfgVehicles.hpp
@@ -16,10 +16,6 @@ class CfgVehicles {
         GVARMAIN(isParachute) = 1;
     };
 
-    class JLTS_Clone_jumppack_mc: B_Kitbag_rgr {
-        GVARMAIN(isParachute) = 1;
-    };
-
     class JLTS_B1_jetpack: B_Kitbag_rgr {
         GVARMAIN(isParachute) = 1;
     };

--- a/addons/compat_jlts/config.cpp
+++ b/addons/compat_jlts/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = AUTHOR;
+        authors[] = {"DartRuffian"};
+        url = ECSTRING(main,url);
+        name = COMPONENT_NAME;
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "aftb_loadorder",
+            "JLTS_jumppacks"
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+
+        skipWhenMissingDependencies = 1;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_jlts/script_component.hpp
+++ b/addons/compat_jlts/script_component.hpp
@@ -1,0 +1,9 @@
+#define COMPONENT compat_jlts
+#define COMPONENT_BEAUTIFIED Just Like The Simulations Compatibility
+#include "\z\aftb\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\z\aftb\addons\main\script_macros.hpp"

--- a/addons/compat_tas/$PBOPREFIX$
+++ b/addons/compat_tas/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\aftb\addons\compat_tas

--- a/addons/compat_tas/CfgVehicles.hpp
+++ b/addons/compat_tas/CfgVehicles.hpp
@@ -1,0 +1,21 @@
+class CfgVehicles {
+    class Helicopter_Base_H;
+    class 3AS_laat_Base: Helicopter_Base_H {
+        GVARMAIN(rampAnims)[] = {{"ramp", 0, 1}};
+
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+
+        EGVAR(helocast,boatPositions)[] = {
+            {0, -1, 4}
+        };
+        EGVAR(helocast,marker) = "Chemlight_green";
+    };
+
+    class 3AS_LAAT_Cargo_Base: 3AS_laat_Base {
+        EGVAR(staticLine,enabled) = 0;
+        EGVAR(staticLine,condition) = QUOTE(false);
+
+        EGVAR(helocast,boatPositions)[] = {};
+    };
+};

--- a/addons/compat_tas/config.cpp
+++ b/addons/compat_tas/config.cpp
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = AUTHOR;
+        authors[] = {"Nightwolf2113", "DartRuffian"};
+        url = ECSTRING(main,url);
+        name = COMPONENT_NAME;
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "aftb_loadorder",
+            "3AS_LAAT",
+            "3AS_LAAT_Cargo"
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+
+        skipWhenMissingDependencies = 1;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_tas/script_component.hpp
+++ b/addons/compat_tas/script_component.hpp
@@ -1,0 +1,9 @@
+#define COMPONENT compat_tas
+#define COMPONENT_BEAUTIFIED 3AS (Beta Test) Compatibility
+#include "\z\aftb\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\z\aftb\addons\main\script_macros.hpp"

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ The following mods have compatability patches built into AFTB.
 I am not currently taking suggestions for adding compatability to more mods. The vehicle you are suggesting likely already has a supported version in a mod listed below. If there is a specific vehicle you would like to add AFTB functionality do, check out the [documentation](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/docs/frameworks).
 
 - [Legion Studios: Core](https://steamcommunity.com/sharedfiles/filedetails/?id=2162749089)
+- [3AS (Beta Test)](https://steamcommunity.com/sharedfiles/filedetails/?id=2058554822)
 - [Operation TREBUCHET](https://steamcommunity.com/workshop/filedetails/?id=769440155)
 - [Operation TREBUCHET First Contact](https://steamcommunity.com/sharedfiles/filedetails/?id=1572627279)
 - [CUP Vehicles](https://steamcommunity.com/sharedfiles/filedetails/?id=541888371)

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ The following mods have compatability patches built into AFTB.
 I am not currently taking suggestions for adding compatability to more mods. The vehicle you are suggesting likely already has a supported version in a mod listed below. If there is a specific vehicle you would like to add AFTB functionality do, check out the [documentation](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/docs/frameworks).
 
 - [Legion Studios: Core](https://steamcommunity.com/sharedfiles/filedetails/?id=2162749089)
+- [Just Like the Simulations](https://steamcommunity.com/sharedfiles/filedetails/?id=1940589429)
 - [3AS (Beta Test)](https://steamcommunity.com/sharedfiles/filedetails/?id=2058554822)
 - [Operation TREBUCHET](https://steamcommunity.com/workshop/filedetails/?id=769440155)
 - [Operation TREBUCHET First Contact](https://steamcommunity.com/sharedfiles/filedetails/?id=1572627279)


### PR DESCRIPTION
Alternative to #40 

**When merged this pull request will:**
- Mark JLTS jumppacks as parachutes
- Add static line and helocast functions to the 3AS LAAT/i

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None