### PR TITLE
Static Line - Fix creating multiple parachutes when ejecting in Multiplayer

### DIFF
--- a/addons/staticline/functions/fnc_createParachute.sqf
+++ b/addons/staticline/functions/fnc_createParachute.sqf
@@ -37,4 +37,6 @@ if (backpack _unit == "") then {
     // A reserve parachute itself obviously doesn't have another reserve, manually set the "canCut" variable
 };
 
+TRACE_3("Created parachute",_unit,_parachuteClass,_parachute);
+
 _parachute;

--- a/addons/staticline/functions/fnc_getOutMan.sqf
+++ b/addons/staticline/functions/fnc_getOutMan.sqf
@@ -22,6 +22,8 @@
 params ["_unit", "", "_vehicle", "", "_isEject"];
 TRACE_3("fnc_getOutMan",_vehicle,_unit,_isEject);
 
+if (!local _unit) exitWith {};
+
 if (_isEject and {[_vehicle, _unit] call FUNC(canJump)}) then {
     [_vehicle, _unit] call FUNC(jump);
 };

--- a/addons/staticline/functions/fnc_jump.sqf
+++ b/addons/staticline/functions/fnc_jump.sqf
@@ -44,11 +44,18 @@ private _delay = (GVAR(parachuteDelay) + random 1) max 0;
     private _parachute = objNull;
 
     if (_hasParachute) then {
-        _unit action ["OpenParachute", _unit];
+        TRACE_1("Unit has a parachute, open existing one",_unit);
+        if (isNull objectParent _unit) then {
+            _unit action ["OpenParachute", _unit];
+        } else {
+            WARNING_2("Unit %1 exited vehicle, but still is inside vehicle (%2)!",_unit,objectParent _unit);
+        };
+
         private _velocity = velocity _unit;
         _parachute = objectParent _unit;
         _parachute setVelocity _velocity;
     } else {
+        TRACE_1("Unit does not have a parachute, create one",_unit);
         _parachute = _unit call FUNC(createParachute);
     };
 

--- a/addons/staticline/functions/fnc_jump.sqf
+++ b/addons/staticline/functions/fnc_jump.sqf
@@ -48,7 +48,7 @@ private _delay = (GVAR(parachuteDelay) + random 1) max 0;
         if (isNull objectParent _unit) then {
             _unit action ["OpenParachute", _unit];
         } else {
-            WARNING_2("Unit %1 exited vehicle, but still is inside vehicle (%2)!",_unit,objectParent _unit);
+            WARNING_2("Unit %1 exited vehicle, but was put into another vehicle (%2)!",_unit,objectParent _unit);
         };
 
         private _velocity = velocity _unit;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `fnc_getOutMan` not filtering out remote players, resulting in extra parachutes for ejecting units
- Add some extra debug / warning info

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- None