### PR TITLE
StaticLine/Helocast - Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ I am not currently taking suggestions for adding compatability to more mods. The
 - [RHSGREF](https://steamcommunity.com/sharedfiles/filedetails/?id=843593391)
 - [RHSSAF](https://steamcommunity.com/sharedfiles/filedetails/?id=843632231)
 - [Hatchet H-60 Pack](https://steamcommunity.com/sharedfiles/filedetails/?id=1745501605)
+- [3CB Factions](https://steamcommunity.com/workshop/filedetails/?id=1673456286)
 
 ### CDLC
 The following creator DLCs have compatability patches built into AFTB.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The project is entirely **open-source** and any contributions are welcome.
 ## Contributing
 For new contributers, see the [Contributing Setup & Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/.github/CONTRIBUTING.md).
 
-## Compatability
+## Compatibility
 ### Mods
-The following mods have compatability patches built into AFTB.
-I am not currently taking suggestions for adding compatability to more mods. The vehicle you are suggesting likely already has a supported version in a mod listed below. If there is a specific vehicle you would like to add AFTB functionality do, check out the [documentation](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/docs/frameworks).
+The following mods have compatibility patches built into AFTB.
+I am not currently taking suggestions for adding compatibility to more mods. The vehicle you are suggesting likely already has a supported version in a mod listed below. If there is a specific vehicle you would like to add AFTB functionality do, check out the [documentation](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/docs/frameworks).
 
 - [Legion Studios: Core](https://steamcommunity.com/sharedfiles/filedetails/?id=2162749089)
 - [Just Like the Simulations](https://steamcommunity.com/sharedfiles/filedetails/?id=1940589429)
@@ -57,9 +57,9 @@ I am not currently taking suggestions for adding compatability to more mods. The
 - [3CB Factions](https://steamcommunity.com/workshop/filedetails/?id=1673456286)
 
 ### CDLC
-The following creator DLCs have compatability patches built into AFTB.
+The following creator DLCs have compatibility patches built into AFTB.
 > [!NOTE]
-> I, DartRuffian, do not own any CDLC content, these patches are tested with the "compatability data" mods.
+> I, DartRuffian, do not own any CDLC content, these patches are tested with the "compatibility data" mods.
 
 - [Western Sahara](https://store.steampowered.com/app/1681170/Arma_3_Creator_DLC_Western_Sahara)
 - [S.O.G. Prairie Fire](https://store.steampowered.com/app/1227700/Arma_3_Creator_DLC_SOG_Prairie_Fire)

--- a/addons/common/CfgVehicles.hpp
+++ b/addons/common/CfgVehicles.hpp
@@ -5,8 +5,16 @@ class CfgVehicles {
     };
 
     class Helicopter_Base_H;
+    class Heli_Transport_02_base_F: Helicopter_Base_H {
+        GVARMAIN(rampAnims)[] = {{"cargoramp_open", 0, 1}};
+    };
     class Heli_Transport_03_base_F: Helicopter_Base_H {
         GVARMAIN(rampAnims)[] = {{"Door_rear_source", 0, 1}}; // animationSource, closedState, openState
+    };
+
+    class Heli_Transport_04_base_F;
+    class O_Heli_Transport_04_covered_F: Heli_Transport_04_base_F {
+        GVARMAIN(rampAnims)[] = {{"Door_6_source", 0, 1}};
     };
 
     class VTOL_01_unarmed_base_F;

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -3,6 +3,8 @@
     <Package name="Common">
         <Key ID="STR_AFTB_common_displayName">
             <English>Common</English>
+            <Italian>Comune</Italian>
+            <German>Allgemein</German>
         </Key>
     </Package>
 </Project>

--- a/addons/compat_3cbfactions/$PBOPREFIX$
+++ b/addons/compat_3cbfactions/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\aftb\addons\compat_3cbfactions

--- a/addons/compat_3cbfactions/CfgVehicles.hpp
+++ b/addons/compat_3cbfactions/CfgVehicles.hpp
@@ -1,0 +1,9 @@
+class CfgVehicles {
+    class VTOL_01_base_F;
+    class UK3CB_Osprey_Base: VTOL_01_base_F {
+        GVARMAIN(rampAnims)[] = {{"Ramp", 0, 1}};
+
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+};

--- a/addons/compat_3cbfactions/config.cpp
+++ b/addons/compat_3cbfactions/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        author = AUTHOR;
+        authors[] = {"DartRuffian", "mrschick"};
+        url = ECSTRING(main,url);
+        name = COMPONENT_NAME;
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "aftb_loadorder",
+            "uk3cb_factions_vehicles_osprey"
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+
+        skipWhenMissingDependencies = 1;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_3cbfactions/config.cpp
+++ b/addons/compat_3cbfactions/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
     class ADDON {
         author = AUTHOR;
-        authors[] = {"DartRuffian", "mrschick"};
+        authors[] = {"mrschick"};
         url = ECSTRING(main,url);
         name = COMPONENT_NAME;
         requiredVersion = REQUIRED_VERSION;

--- a/addons/compat_3cbfactions/script_component.hpp
+++ b/addons/compat_3cbfactions/script_component.hpp
@@ -1,0 +1,9 @@
+#define COMPONENT compat_3cbfactions
+#define COMPONENT_BEAUTIFIED 3CB Factions Compatibility
+#include "\z\aftb\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\z\aftb\addons\main\script_macros.hpp"

--- a/addons/compat_ls/script_component.hpp
+++ b/addons/compat_ls/script_component.hpp
@@ -1,5 +1,5 @@
 #define COMPONENT compat_ls
-#define COMPONENT_BEAUTIFIED Legion Studios Compatability
+#define COMPONENT_BEAUTIFIED Legion Studios Compatibility
 #include "\z\aftb\addons\main\script_mod.hpp"
 
 // #define DEBUG_MODE_FULL

--- a/addons/compat_rhs_afrf/CfgVehicles.hpp
+++ b/addons/compat_rhs_afrf/CfgVehicles.hpp
@@ -1,2 +1,6 @@
 class CfgVehicles {
+    class Heli_Attack_02_base_F;
+    class rhs_mi28_base: Heli_Attack_02_base_F {
+        EGVAR(staticLine,enabled) = 0;
+    };
 };

--- a/addons/compat_rhs_usaf/CfgVehicles.hpp
+++ b/addons/compat_rhs_usaf/CfgVehicles.hpp
@@ -10,6 +10,7 @@ class CfgVehicles {
             {0, 5.75, -2.59},
             {0, 0.8, -2.59}
         };
+        EGVAR(helocast,minUnloadDistance) = 12;
     };
 
     class Heli_light_03_base_F;
@@ -46,6 +47,7 @@ class CfgVehicles {
             {0, -3.27, -1.3}
         };
         EGVAR(helocast,marker) = "Chemlight_green";
+        EGVAR(helocast,minUnloadDistance) = 12;
     };
 
     class RHS_CH_47F_cargo_base: RHS_CH_47F_base {

--- a/addons/compat_rhs_usaf/CfgVehicles.hpp
+++ b/addons/compat_rhs_usaf/CfgVehicles.hpp
@@ -3,15 +3,29 @@ class CfgVehicles {
     class rhsusf_CH53E_USMC: Helicopter_Base_H {
         GVARMAIN(rampAnims)[] = {{"ramp", 0, 0.56}};
 
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+
         EGVAR(helocast,boatPositions)[] = {
             {0, 5.75, -2.59},
             {0, 0.8, -2.59}
         };
     };
 
+    class Heli_light_03_base_F;
+    class RHS_UH1_Base: Heli_light_03_base_F {
+        GVARMAIN(rampAnims)[] = {{"doorhandler_l", 0, 1}, {"doorhandler_r", 0, 1}};
+
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
+    };
+
     class RHS_UH60_Base;
     class RHS_UH60M_base: RHS_UH60_Base {
-        GVARMAIN(rampAnims)[] = {{"", 0, 0}};
+        GVARMAIN(rampAnims)[] = {{"doorhandler_l", 0, 1}, {"doorhandler_r", 0, 1}};
+
+        EGVAR(staticLine,enabled) = 1;
+        EGVAR(staticLine,condition) = QUOTE(true);
 
         EGVAR(helocast,boatPositions)[] = {
             {0, 1.8, -1.45}

--- a/addons/helocast/stringtable.xml
+++ b/addons/helocast/stringtable.xml
@@ -3,42 +3,68 @@
     <Package name="Helocast">
         <Key ID="STR_AFTB_helocast_action_helocast">
             <English>Helocast</English>
+            <Italian>Helocast</Italian>
+            <German>Helocast</German>
         </Key>
         <Key ID="STR_AFTB_helocast_action_recoverBoat">
             <English>Recover Boat</English>
+            <Italian>Recupera barca</Italian>
+            <German>Boot einladen</German>
         </Key>
         <Key ID="STR_AFTB_helocast_action_removeMarker">
             <English>Remove Marker</English>
+            <Italian>Rimuovi marcatore</Italian>
+            <German>Marker entfernen</German>
         </Key>
         <Key ID="STR_AFTB_helocast_action_unloadBoat">
             <English>Unload %1</English>
+            <Italian>Sgancia %1</Italian>
+            <German>Lade %1 aus</German>
         </Key>
         <Key ID="STR_AFTB_helocast_action_unloadBoats">
             <English>Unload Boats</English>
+            <Italian>Sgancia barche</Italian>
+            <German>Boote ausladen</German>
         </Key>
         <Key ID="STR_AFTB_helocast_boatCount_displayName">
             <English>Boat count</English>
+            <Italian>Numero di barche</Italian>
+            <German>Anzahl an Booten</German>
         </Key>
         <Key ID="STR_AFTB_helocast_boatCount_tooltip">
             <English>How many of the given boat type to load.</English>
+            <Italian>Numero di barche (di questo tipo) da caricare.</Italian>
+            <German>Anzahl an Booten (dieser Klasse) die einzuladen sind.</German>
         </Key>
         <Key ID="STR_AFTB_helocast_boatType_displayName">
             <English>Boat type</English>
+            <Italian>Tipo di barca</Italian>
+            <German>Bootsklasse</German>
         </Key>
         <Key ID="STR_AFTB_helocast_boatType_tooltip">
             <English>What type of boat to load into the aircraft when the mission is started.</English>
+            <Italian>Il tipo di barca da caricare nel velivolo a inizio missione.</Italian>
+            <German>Die Bootsklasse die bei Missionsbeginn in das Flugzeug einzuladen ist.</German>
         </Key>
         <Key ID="STR_AFTB_helocast_displayName">
             <English>Helocast</English>
+            <Italian>Helocast</Italian>
+            <German>Helocast</German>
         </Key>
         <Key ID="STR_AFTB_helocast_enabled_tooltip">
             <English>Enables / disables helocasting.</English>
+            <Italian>Abilita / Disabilita il helocasting.</Italian>
+            <German>Aktiviert / Deaktiviert das Helocasting.</German>
         </Key>
         <Key ID="STR_AFTB_helocast_loadDistance_name">
             <English>Load Distance</English>
+            <Italian>Distanza di recupero</Italian>
+            <German>Einlad-Entfernung</German>
         </Key>
         <Key ID="STR_AFTB_helocast_loadDistance_tooltip">
             <English>Distance in meters that boats are able to load into helicopters from.</English>
+            <Italian>Distanza in metri entro cui è possibile recupare una barca nell'elicottero.</Italian>
+            <German>Entfernung in Metern aus der es möglich ist ein Boot in den Hubschrauber einzuladen.</German>
         </Key>
     </Package>
 </Project>

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -3,9 +3,13 @@
     <Package name="Main">
         <Key ID="STR_AFTB_main_disconnectMismatchedVersions_name">
             <English>Disconnect Mismatched Versions</English>
+            <Italian>Disconnetti versioni diverse</Italian>
+            <German>Trenne Spieler mit anderer Version</German>
         </Key>
         <Key ID="STR_AFTB_main_disconnectMismatchedVersions_tooltip">
             <English>If enabled, clients with a version of AFTB different from the server will be disconnected.</English>
+            <Italian>Se abilitato, i giocatori con una versione di AFTB differente dal server verranno disconnessi.</Italian>
+            <German>Wenn aktiviert, werden Spieler mit einer anderen AFTB Version als die des Servers getrennt.</German>
         </Key>
         <Key ID="STR_AFTB_main_url">
             <English>https://github.com/DartsArmaMods/AimForTheBushes</English>

--- a/addons/staticline/CfgVehicles.hpp
+++ b/addons/staticline/CfgVehicles.hpp
@@ -13,7 +13,28 @@ class CfgVehicles {
     };
 
     class Helicopter_Base_H;
+    class Heli_Light_02_base_F: Helicopter_Base_H {
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
+    };
+    class Heli_light_03_base_F: Helicopter_Base_H {
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
+    };
+
+    class Heli_Transport_01_base_F: Helicopter_Base_H {
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
+    };
+    class Heli_Transport_02_base_F: Helicopter_Base_H {
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
+    };
     class Heli_Transport_03_base_F: Helicopter_Base_H {
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
+    };
+    class Heli_Transport_04_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
         GVAR(condition) = QUOTE(true);
     };

--- a/addons/staticline/CfgVehicles.hpp
+++ b/addons/staticline/CfgVehicles.hpp
@@ -13,6 +13,11 @@ class CfgVehicles {
     };
 
     class Helicopter_Base_H;
+    class Heli_Attack_02_base_F: Helicopter_Base_H {
+        GVAR(enabled) = 1;
+        GVAR(condition) = QUOTE(true);
+    };
+
     class Heli_Light_02_base_F: Helicopter_Base_H {
         GVAR(enabled) = 1;
         GVAR(condition) = QUOTE(true);

--- a/addons/staticline/stringtable.xml
+++ b/addons/staticline/stringtable.xml
@@ -3,51 +3,83 @@
     <Package name="StaticLine">
         <Key ID="STR_AFTB_staticLine_action_hook">
             <English>Hook</English>
+            <Italian>Aggancia</Italian>
+            <German>Einhängen</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_action_jump">
             <English>Jump</English>
+            <Italian>Lanciati</Italian>
+            <German>Springe</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_action_staticLine">
             <English>Static Line</English>
+            <Italian>Fune di vincolo</Italian>
+            <German>Reißleine</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_action_unhook">
             <English>Unhook</English>
+            <Italian>Sgancia</Italian>
+            <German>Aushängen</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_aiDeployPlayers_name">
             <English>AI Deploy Players</English>
+            <Italian>IA lancia giocatori</Italian>
+            <German>KI wirft Spieler ab</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_aiDeployPlayers_tooltip">
             <English>If enabled, AI pilots will also deploy players when using the Static Line Jump waypoint.</English>
+            <Italian>Se abilitato, piloti IA faranno lanciare anche giocatori agganciati, quando giungono al proprio waypoint di lancio automatico.</Italian>
+            <German>Wenn aktiviert, werden KI-Piloten eingehängte Spieler abspringen lassen, wenn sie an ihrem Automatensprung-Wegpunkt ankommen.</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_createGroup_name">
             <English>Create New Group</English>
+            <Italian>Crea nuovo gruppo</Italian>
+            <German>Erstelle neue Gruppe</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_createGroup_tooltip">
             <English>If enabled, all jumpers will be automatically moved into a new group. If disabled, jumpers will be left in their original group.</English>
+            <Italian>Se abilitato, tutti i paracadutisti verranno automaticamente spostati in un nuovo gruppo. Altrimenti rimarranno nel loro gruppo originale.</Italian>
+            <German>Wenn aktiviert, werden alle Springer in eine neue Gruppe verschoben. Falls nicht, verbleiben sie in ihrer aktuellen Gruppe.</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_defaultParachute_name">
             <English>Default Parachute</English>
+            <Italian>Paracadute predefinito</Italian>
+            <German>Standard Fallschirm</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_defaultParachute_tooltip">
             <English>The default parachute (vehicle) class to use when a unit ejects without a parachute equipped.</English>
+            <Italian>La classe del veicolo paracadute da utilizzare quando un'unità si lancia senza aver equipaggiato un paracadute.</Italian>
+            <German>Die Fahrzeug-Klasse des Fallschirms der verwendet wird falls eine Einheit abspringt ohne einen Fallschirm zu tragen.</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_defaultReserveParachute_name">
             <English>Default Reserve Parachute</English>
+            <Italian>Paracadute di riserva predefinito</Italian>
+            <German>Standard Reserve Fallschirm</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_defaultReserveParachute_tooltip">
             <English>The default reserve parachute (backpack) class to add to units who jump without a backpack at all.</English>
+            <Italian>La classe del veicolo paracadute di riserva da aggiungere ad un'unità che si è lanciata senza uno zaino.</Italian>
+            <German>Die Fahrzeug-Klasse des Reserve-Fallschirms der einer Einheit angezogen wird, falls diese ohne einen Rucksack abspringt.</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_displayName">
             <English>Static Line Jump</English>
+            <Italian>Lancio automatico da fune</Italian>
+            <German>Automatischer Leinensprung</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_enabled_tooltip">
             <English>Enables / disables static line jumping from vehicles.</English>
+            <Italian>Abilita / Disabilita lanci con apertura automatica da velivoli.</Italian>
+            <German>Aktiviert / Deaktiviert Automatensprünge mit Aufziehleine von Flugzeugen.</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_parachuteDelay_name">
             <English>Parachute Delay</English>
+            <Italian>Intervallo di apertura</Italian>
+            <German>Fallschirm-Öffnungsverzögerung</German>
         </Key>
         <Key ID="STR_AFTB_staticLine_parachuteDelay_tooltip">
             <English>The minimum amount of time in seconds before deploying a unit's parachute. There will be a small offset to this time (0-1 seconds)</English>
+            <Italian>Il minimo intervallo in secondi tra il salto e l'apertura del paracadute. È seguito da un ulteriore intervallo casuale tra 0-1 secondi.</Italian>
+            <German>Die Mindestdauer in Sekunden zwischen Absprung und Öffnung, gefolgt von einer weiteren zufälligen Verzögerung von bis zu einer Sekunde.</German>
         </Key>
     </Package>
 </Project>

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ I am not currently taking suggestions for adding compatability to more mods. The
 - [RHSGREF](https://steamcommunity.com/sharedfiles/filedetails/?id=843593391)
 - [RHSSAF](https://steamcommunity.com/sharedfiles/filedetails/?id=843632231)
 - [Hatchet H-60 Pack](https://steamcommunity.com/sharedfiles/filedetails/?id=1745501605)
+- [3CB Factions](https://steamcommunity.com/workshop/filedetails/?id=1673456286)
 
 ### CDLC
 The following creator DLCs have compatability patches built into AFTB.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,10 +32,10 @@ The project is entirely **open-source** and any contributions are welcome.
 ## Contributing
 For new contributers, see the [Contributing Setup & Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/.github/CONTRIBUTING.md).
 
-## Compatability
+## Compatibility
 ### Mods
-The following mods have compatability patches built into AFTB.
-I am not currently taking suggestions for adding compatability to more mods. The vehicle you are suggesting likely already has a supported version in a mod listed below. If there is a specific vehicle you would like to add AFTB functionality do, check out the [documentation](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/docs/frameworks).
+The following mods have compatibility patches built into AFTB.
+I am not currently taking suggestions for adding compatibility to more mods. The vehicle you are suggesting likely already has a supported version in a mod listed below. If there is a specific vehicle you would like to add AFTB functionality do, check out the [documentation](https://github.com/DartsArmaMods/AimForTheBushes/blob/main/docs/frameworks).
 
 - [Legion Studios: Core](https://steamcommunity.com/sharedfiles/filedetails/?id=2162749089)
 - [Just Like the Simulations](https://steamcommunity.com/sharedfiles/filedetails/?id=1940589429)
@@ -57,9 +57,9 @@ I am not currently taking suggestions for adding compatability to more mods. The
 - [3CB Factions](https://steamcommunity.com/workshop/filedetails/?id=1673456286)
 
 ### CDLC
-The following creator DLCs have compatability patches built into AFTB.
+The following creator DLCs have compatibility patches built into AFTB.
 > [!NOTE]
-> I, DartRuffian, do not own any CDLC content, these patches are tested with the "compatability data" mods.
+> I, DartRuffian, do not own any CDLC content, these patches are tested with the "compatibility data" mods.
 
 - [Western Sahara](https://store.steampowered.com/app/1681170/Arma_3_Creator_DLC_Western_Sahara)
 - [S.O.G. Prairie Fire](https://store.steampowered.com/app/1227700/Arma_3_Creator_DLC_SOG_Prairie_Fire)


### PR DESCRIPTION
**When merged this pull request will:**
- **Add SLJ to vanilla medium/large utility/transport helicopters that previously didn't have it**
Since IRL medium-sized helos support SLJs, vanilla helicopters like the Ghosthawk, Orca and Taru (DLC) should too.
The behaviour also inherits down to DLC helicopters the Mi-8, which isn't an issue IMO. However, for the future it might be better to only add the enable flag to `B_Heli_<Type>_0N_F` child classes, to avoid unwanted inheritance to any mod that probably uses the baseclasses.
- **Add SLJ to vanilla Mi-48 Kajman**
Since the CSAT Attack Helicopter can carry passengers and also fastrope with ACE3, it should also support SLJ.
The behaviour inherits down to the Mi-24, which should be ok. It also inherits to the RHSAFRF Mi-28, which is fixed by disabling it for that class.
- **Add SLJ to RHSUSAF Helicopters that can perform it IRL, like the [CH-53](https://youtu.be/y94soIkwz9k), [UH-1](https://youtu.be/1OW9RGkhYVw) and [UH-60](https://youtu.be/5QGBIZpeGvM)**
- **Create a compat for the [3CB Factions](https://steamcommunity.com/workshop/filedetails/?id=1673456286) mod, in order to add SLJ to [the capable V-22 Osprey](https://youtu.be/Y21MFoq19GI)**
- **Fix helocasted boats getting stuck inside the RHS CH-47 and CH-53, since they are just too long.**
Resolved by simply increasing their minimum unload distance. A cleaner fix for the future could be making the config-defined unload distance be relative to the helicopter's center, instead of the boat's loaded position. That way all loaded boats would slide out in the same way, regardless of their loaded position.
- **Full Italian+German translation of all components**

### Important
- [x] If the contribution affects [the documentation](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/docs), please include your changes in this pull request.
- [x] [Development Guidelines](https://github.com/DartsArmaMods/AimForTheBushes/tree/main/.github/CONTRIBUTING.md) are read, understood and applied.
- [x] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.

<!-- Known issues that need to be addressed -->
### Known Issues
- [ ] Inheritance of the staticline enable flag through `Heli_<Type>_0N_Base_F` classes may cause some helicopters to be able to use it that shouldn't. So far that isn't the case for Vanilla+RHS+3CB helis as far as I can tell, but it may affect other mods.