### PR TITLE
Static Line - Reset unitsToDeploy on waypoint finish

### DIFF
--- a/addons/staticline/functions/fnc_jumpAIRecursive.sqf
+++ b/addons/staticline/functions/fnc_jumpAIRecursive.sqf
@@ -21,8 +21,9 @@ params ["_vehicle", "_unitsToDeploy", "_jumpInterval"];
 TRACE_3("fnc_jumpAI_recursive",_vehicle,_unitsToDeploy,_jumpInterval);
 
 private _unit = _unitsToDeploy deleteAt 0;
-[_vehicle, _unit] call FUNC(jump);
-
+if (_unit in _vehicle) then {
+    [_vehicle, _unit] call FUNC(jump);
+};
 if (_unitsToDeploy isNotEqualTo []) then {
     [{
         _this call FUNC(jumpAIRecursive);

--- a/addons/staticline/functions/fnc_jumpAIRecursive.sqf
+++ b/addons/staticline/functions/fnc_jumpAIRecursive.sqf
@@ -27,6 +27,8 @@ if (_unitsToDeploy isNotEqualTo []) then {
     [{
         _this call FUNC(jumpAIRecursive);
     }, _this, _jumpInterval] call CBA_fnc_waitAndExecute;
+} else {
+    _vehicle setVariable [QGVAR(unitsToDeploy), _unitsToDeploy, true];
 };
 
 nil;

--- a/addons/staticline/functions/fnc_jumpAIWaypoint.sqf
+++ b/addons/staticline/functions/fnc_jumpAIWaypoint.sqf
@@ -61,7 +61,7 @@ sleep 2;
 
 // - Deployment ---------------------------------------------------------------
 _vehicle call FUNC(jumpAI);
-waitUntil {(_vehicle getVariable [QGVAR(unitsToDeploy), []]) isEqualTo []};
+waitUntil {sleep 0.5; (_vehicle getVariable [QGVAR(unitsToDeploy), []]) isEqualTo [];}; //Not necessary, but if the jump interval is long then there is no point in checking every frame
 
 #ifdef DEBUG_MODE_FULL
     deleteMarker _wpMarker;


### PR DESCRIPTION
**When merged this pull request will:**
- Set QGVAR(unitsToDeploy) to [] variable when vehicle empty 
- Waituntil sleep with sleep, not necessary, but if the jump interval is long then there is no point in checking every frame 

**Current Issue**
https://github.com/DartsArmaMods/AimForTheBushes/blob/18b92e161cd60d986b906fdf0ac94c92222679d5/addons/staticline/functions/fnc_jumpAIWaypoint.sqf#L64

Doenst return True, -> variable is not updated when units to deploy array is empty.